### PR TITLE
feat(loans): add Chart.js visualizations for loan detail & list views…

### DIFF
--- a/expenses/tests/test_loans.py
+++ b/expenses/tests/test_loans.py
@@ -152,3 +152,23 @@ class LoanServiceTest(TestCase):
 
         response = self.client.get(reverse('loan-list'))
         self.assertRedirects(response, reverse('pricing'))
+
+    def test_loan_views_include_chart_data(self):
+        self.client.force_login(self.user)
+
+        # Test LoanListView context contains portfolio & loan comparison chart data
+        list_response = self.client.get(reverse('loan-list'))
+        self.assertEqual(list_response.status_code, 200)
+        self.assertIn('portfolio_breakdown_chart', list_response.context)
+        self.assertIn('loan_comparison_chart', list_response.context)
+        self.assertContains(list_response, 'id="portfolioBreakdownChart"')
+        self.assertContains(list_response, 'id="loanComparisonChart"')
+
+        # Test LoanDetailView context contains breakdown & amortization chart data
+        detail_response = self.client.get(reverse('loan-detail', kwargs={'pk': self.loan.pk}))
+        self.assertEqual(detail_response.status_code, 200)
+        self.assertIn('breakdown_chart_data', detail_response.context)
+        self.assertIn('amortization_chart_data', detail_response.context)
+        self.assertContains(detail_response, 'id="loanBreakdownChart"')
+        self.assertContains(detail_response, 'id="loanAmortizationChart"')
+

--- a/expenses/views/loans.py
+++ b/expenses/views/loans.py
@@ -119,12 +119,30 @@ class LoanListView(HtmxPartialTemplateMixin, LoginRequiredMixin, LoanFeatureGate
             for l in all_loans if l.is_active
         )
 
+        # Portfolio Chart Data
+        tot_principal_paid = sum(s['principal_paid'] + s['capital_prepaid'] for s in loan_summaries)
+        tot_interest_paid = sum(s['interest_paid'] for s in loan_summaries)
+        tot_remaining_debt = sum(s['remaining_principal'] for s in loan_summaries)
+
+        portfolio_breakdown_chart = {
+            'labels': [_('Principal Paid'), _('Interest Paid'), _('Remaining Debt')],
+            'values': [round(tot_principal_paid, 2), round(tot_interest_paid, 2), round(tot_remaining_debt, 2)],
+        }
+
+        loan_comparison_chart = {
+            'labels': [s['loan'].name for s in loan_summaries],
+            'principal_paid': [round(s['principal_paid'] + s['capital_prepaid'], 2) for s in loan_summaries],
+            'remaining_principal': [round(s['remaining_principal'], 2) for s in loan_summaries],
+        }
+
         context['loan_summaries'] = loan_summaries
         context['total_debt'] = total_debt
         context['status_filter'] = status_filter
         context['active_count'] = active_count
         context['inactive_count'] = inactive_count
         context['all_count'] = all_count
+        context['portfolio_breakdown_chart'] = portfolio_breakdown_chart
+        context['loan_comparison_chart'] = loan_comparison_chart
         return context
 
 class LoanCreateView(LoginRequiredMixin, LoanFeatureGateMixin, CreateView):
@@ -216,6 +234,127 @@ class LoanDetailView(LoginRequiredMixin, LoanFeatureGateMixin, View):
         ).select_related('account').order_by('date')
         linked_capital_total = sum(float(e.base_amount) for e in linked_capital_events)
 
+        principal_paid_total = round(summary['principal_paid'] + summary['capital_prepaid'], 2)
+        interest_paid_total = round(summary['interest_paid'], 2)
+        remaining_principal_total = round(summary['remaining_principal'], 2)
+
+        breakdown_chart_data = {
+            'labels': [_('Principal Paid'), _('Interest Paid'), _('Remaining Principal')],
+            'values': [principal_paid_total, interest_paid_total, remaining_principal_total],
+        }
+
+        # Build amortization chart data:
+        # For active loans: prepend historical repayments/capital events, then append future schedule
+        # For paid-off loans: show full historical trajectory only
+        from collections import defaultdict
+
+        def _build_historical_months(loan_repayments, capital_events, initial_principal):
+            """Aggregate past repayments and capital events by month, return sorted monthly data."""
+            all_events = []
+            for r in loan_repayments.order_by('date'):
+                all_events.append({
+                    'date': r.date,
+                    'principal': float(r.principal_portion or 0),
+                    'interest': float(r.interest_portion or 0),
+                    'type': 'emi',
+                })
+            for c in capital_events:
+                all_events.append({
+                    'date': c.date,
+                    'principal': float(c.base_amount or 0),
+                    'interest': 0.0,
+                    'type': 'capital',
+                })
+            all_events.sort(key=lambda x: x['date'])
+
+            monthly_map = defaultdict(lambda: {'principal': 0.0, 'interest': 0.0})
+            for ev in all_events:
+                m_key = ev['date'].strftime('%b %Y')
+                monthly_map[m_key]['principal'] += ev['principal']
+                monthly_map[m_key]['interest'] += ev['interest']
+
+            h_labels, h_principals, h_interests, h_balances = [], [], [], []
+            curr_balance = float(initial_principal)
+            for m_key, vals in monthly_map.items():
+                h_labels.append(m_key)
+                h_principals.append(round(vals['principal'], 2))
+                h_interests.append(round(vals['interest'], 2))
+                curr_balance = max(0.0, curr_balance - vals['principal'])
+                h_balances.append(round(curr_balance, 2))
+            return h_labels, h_principals, h_interests, h_balances
+
+        # Check if there's any prior payment history (EMIs or capital events)
+        has_prior_history = repayments.exists() or linked_capital_events.exists()
+
+        if schedule:
+            hist_labels, hist_principals, hist_interests, hist_balances = [], [], [], []
+            if has_prior_history:
+                hist_labels, hist_principals, hist_interests, hist_balances = _build_historical_months(
+                    loan.repayments.order_by('date'),
+                    linked_capital_events,
+                    loan.initial_principal,
+                )
+            amortization_chart_data = {
+                'labels': hist_labels + [item['month'] for item in schedule],
+                'principal': hist_principals + [item['principal'] for item in schedule],
+                'interest': hist_interests + [item['interest'] for item in schedule],
+                'balance': hist_balances + [item['balance'] for item in schedule],
+                'history_count': len(hist_labels),   # how many data points are historical
+                'is_historical': False,
+            }
+        elif has_prior_history:
+            # Generate historical trajectory for paid-off or past loans
+            all_events = []
+            for r in loan.repayments.order_by('date'):
+                all_events.append({
+                    'date': r.date,
+                    'principal': float(r.principal_portion or 0),
+                    'interest': float(r.interest_portion or 0),
+                })
+            for c in linked_capital_events:
+                all_events.append({
+                    'date': c.date,
+                    'principal': float(c.base_amount or 0),
+                    'interest': 0.0,
+                })
+            all_events.sort(key=lambda x: x['date'])
+
+            from collections import defaultdict
+            monthly_map = defaultdict(lambda: {'principal': 0.0, 'interest': 0.0})
+            for ev in all_events:
+                m_key = ev['date'].strftime('%b %Y')
+                monthly_map[m_key]['principal'] += ev['principal']
+                monthly_map[m_key]['interest'] += ev['interest']
+
+            labels = []
+            principals = []
+            interests = []
+            balances = []
+            curr_balance = float(loan.initial_principal)
+
+            for m_key, vals in monthly_map.items():
+                labels.append(m_key)
+                principals.append(round(vals['principal'], 2))
+                interests.append(round(vals['interest'], 2))
+                curr_balance = max(0.0, curr_balance - vals['principal'])
+                balances.append(round(curr_balance, 2))
+
+            amortization_chart_data = {
+                'labels': labels,
+                'principal': principals,
+                'interest': interests,
+                'balance': balances,
+                'is_historical': True,
+            }
+        else:
+            amortization_chart_data = {
+                'labels': [],
+                'principal': [],
+                'interest': [],
+                'balance': [],
+                'is_historical': False,
+            }
+
         context = {
             'loan': loan,
             'summary': summary,
@@ -226,6 +365,8 @@ class LoanDetailView(LoginRequiredMixin, LoanFeatureGateMixin, View):
             'extra_emi_savings': extra_emi_savings,
             'linked_capital_events': linked_capital_events,
             'linked_capital_total': linked_capital_total,
+            'breakdown_chart_data': breakdown_chart_data,
+            'amortization_chart_data': amortization_chart_data,
         }
         return render(request, self.template_name, context)
 

--- a/templates/expenses/loan_detail.html
+++ b/templates/expenses/loan_detail.html
@@ -66,9 +66,44 @@
         </div>
     </div>
 
-    <div class="row g-4">
-        <!-- Main Content: Schedule & History -->
+    <div class="row g-4 mb-4">
+        <!-- Main Content: Amortization Trend & Schedule & History -->
         <div class="col-lg-8 order-2 order-lg-1">
+            <!-- Amortization Trend Chart Card -->
+            <div class="card border-0 shadow-sm rounded-4 mb-4">
+                <div class="card-header bg-transparent border-0 p-4 pb-0 d-flex justify-content-between align-items-center">
+                    <div>
+                        <h5 class="fw-bold mb-0">
+                            {% if amortization_chart_data.is_historical %}
+                                {% trans "Historical Repayment Trajectory" %}
+                            {% else %}
+                                {% trans "Amortization Trajectory" %}
+                            {% endif %}
+                        </h5>
+                        <p class="text-muted small mb-0">
+                            {% if amortization_chart_data.is_historical %}
+                                {% trans "Historical principal vs. interest breakdown and balance reduction over time." %}
+                            {% else %}
+                                {% trans "Monthly principal vs interest breakdown and balance trajectory." %}
+                            {% endif %}
+                        </p>
+                    </div>
+                </div>
+                <div class="card-body p-4">
+                    {% if amortization_chart_data.labels %}
+                    <div style="position: relative; min-height: 260px; max-height: 320px;">
+                        <canvas id="loanAmortizationChart"></canvas>
+                    </div>
+                    {% else %}
+                    <div class="text-center py-4 text-muted">
+                        <i class="bi bi-bar-chart-line fs-2 text-secondary d-block mb-2"></i>
+                        <h6 class="fw-bold mb-1">{% trans "No Amortization Trajectory Yet" %}</h6>
+                        <p class="small mb-0 text-muted">{% trans "Record your first repayment to start tracking your repayment trajectory." %}</p>
+                    </div>
+                    {% endif %}
+                </div>
+            </div>
+
             <!-- Repayment History -->
             <div class="card border-0 shadow-sm rounded-4 mb-4">
                 <div class="card-header bg-transparent border-0 p-4 pb-0">
@@ -173,8 +208,21 @@
             </div>
         </div>
 
-        <!-- Sidebar Info -->
+        <!-- Sidebar Info & Breakdown Chart -->
         <div class="col-lg-4 order-1 order-lg-2">
+            <!-- Doughnut Chart Card -->
+            <div class="card border-0 shadow-sm rounded-4 mb-4">
+                <div class="card-header bg-transparent border-0 p-4 pb-0">
+                    <h5 class="fw-bold mb-0">{% trans "Loan Structure Breakdown" %}</h5>
+                    <p class="text-muted small">{% trans "Principal vs. Interest distribution." %}</p>
+                </div>
+                <div class="card-body p-4">
+                    <div style="position: relative; height: 220px;">
+                        <canvas id="loanBreakdownChart"></canvas>
+                    </div>
+                </div>
+            </div>
+
             <div class="card border-0 shadow-sm rounded-4 loan-summary mb-4">
                 <div class="card-body p-4">
                     <h5 class="fw-bold mb-3">{% trans "Loan Summary" %}</h5>
@@ -502,6 +550,224 @@
                 recurringToggle.addEventListener('change', syncRecurringVisibility);
             }
         });
+    </script>
+
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    {{ breakdown_chart_data|json_script:"breakdown-chart-data" }}
+    {{ amortization_chart_data|json_script:"amortization-chart-data" }}
+
+    <script>
+    function renderLoanDetailCharts() {
+        if (typeof Chart === 'undefined') return;
+        const isDark = document.documentElement.getAttribute('data-bs-theme') === 'dark';
+        const textColor = isDark ? '#e2e8f0' : '#475569';
+        const gridColor = isDark ? 'rgba(255, 255, 255, 0.08)' : 'rgba(0, 0, 0, 0.05)';
+
+        // 1. Doughnut Chart: Structure Breakdown
+        const breakdownCtx = document.getElementById('loanBreakdownChart');
+        const breakdownDataEl = document.getElementById('breakdown-chart-data');
+        if (breakdownCtx && breakdownDataEl) {
+            if (Chart.getChart(breakdownCtx)) {
+                Chart.getChart(breakdownCtx).destroy();
+            }
+            const data = JSON.parse(breakdownDataEl.textContent);
+            new Chart(breakdownCtx, {
+                type: 'doughnut',
+                data: {
+                    labels: data.labels,
+                    datasets: [{
+                        data: data.values,
+                        backgroundColor: ['#1D9E75', '#F59E0B', '#EF4444'],
+                        borderWidth: 2,
+                        borderColor: isDark ? '#1e293b' : '#ffffff'
+                    }]
+                },
+                options: {
+                    responsive: true,
+                    maintainAspectRatio: false,
+                    plugins: {
+                        legend: {
+                            position: 'bottom',
+                            labels: {
+                                color: textColor,
+                                font: { size: 11, weight: '500' },
+                                padding: 12,
+                                usePointStyle: true
+                            }
+                        },
+                        tooltip: {
+                            callbacks: {
+                                label: function(ctx) {
+                                    const val = ctx.parsed || 0;
+                                    return ` ${ctx.label}: {{ loan.currency }}${val.toLocaleString()}`;
+                                }
+                            }
+                        }
+                    },
+                    cutout: '70%'
+                }
+            });
+        }
+
+        // 2. Amortization Trajectory (Stacked Bar + Line Chart)
+        const amortCtx = document.getElementById('loanAmortizationChart');
+        const amortDataEl = document.getElementById('amortization-chart-data');
+        if (amortCtx && amortDataEl) {
+            if (Chart.getChart(amortCtx)) {
+                Chart.getChart(amortCtx).destroy();
+            }
+            const data = JSON.parse(amortDataEl.textContent);
+            const histCount = data.history_count || 0;
+            const totalPoints = data.labels.length;
+
+            // Color arrays: solid for historical (paid), faded for projected
+            const principalColors = data.labels.map((_, i) =>
+                i < histCount ? 'rgba(29, 158, 117, 0.95)' : 'rgba(29, 158, 117, 0.35)'
+            );
+            const interestColors = data.labels.map((_, i) =>
+                i < histCount ? 'rgba(245, 158, 11, 0.95)' : 'rgba(245, 158, 11, 0.35)'
+            );
+            const balanceColors = data.labels.map((_, i) =>
+                i < histCount ? '#EF4444' : 'rgba(239, 68, 68, 0.4)'
+            );
+
+            // Vertical divider plugin: draw a line between history and projection
+            const dividerPlugin = {
+                id: 'historyDivider',
+                afterDraw(chart) {
+                    if (histCount <= 0 || histCount >= totalPoints) return;
+                    const ctx2 = chart.ctx;
+                    const xAxis = chart.scales.x;
+                    const yAxis = chart.scales.y;
+                    // Position between the last historical bar and first projected bar
+                    const x = (xAxis.getPixelForValue(histCount - 1) + xAxis.getPixelForValue(histCount)) / 2;
+                    ctx2.save();
+                    ctx2.setLineDash([5, 4]);
+                    ctx2.strokeStyle = 'rgba(99, 102, 241, 0.6)';
+                    ctx2.lineWidth = 2;
+                    ctx2.beginPath();
+                    ctx2.moveTo(x, yAxis.top);
+                    ctx2.lineTo(x, yAxis.bottom);
+                    ctx2.stroke();
+                    // "Now" label
+                    ctx2.setLineDash([]);
+                    ctx2.fillStyle = 'rgba(99, 102, 241, 0.9)';
+                    ctx2.font = 'bold 10px Inter, sans-serif';
+                    ctx2.textAlign = 'center';
+                    ctx2.fillText('NOW', x, yAxis.top - 4);
+                    ctx2.restore();
+                }
+            };
+
+            new Chart(amortCtx, {
+                type: 'bar',
+                plugins: [dividerPlugin],
+                data: {
+                    labels: data.labels,
+                    datasets: [
+                        {
+                            label: '{% trans "Principal" %}',
+                            data: data.principal,
+                            backgroundColor: principalColors,
+                            stack: 'Stack 0',
+                            order: 2
+                        },
+                        {
+                            label: '{% trans "Interest" %}',
+                            data: data.interest,
+                            backgroundColor: interestColors,
+                            stack: 'Stack 0',
+                            order: 2
+                        },
+                        {
+                            label: '{% trans "Remaining Balance" %}',
+                            data: data.balance,
+                            type: 'line',
+                            borderColor: '#EF4444',
+                            backgroundColor: 'rgba(239, 68, 68, 0.08)',
+                            borderWidth: 2,
+                            pointRadius: data.labels.map((_, i) => i < histCount ? 3 : 2),
+                            pointBackgroundColor: balanceColors,
+                            fill: false,
+                            tension: 0.3,
+                            segment: {
+                                borderDash: ctx => ctx.p0DataIndex >= histCount - 1 ? [5, 4] : [],
+                                borderColor: ctx => ctx.p0DataIndex < histCount ? '#EF4444' : 'rgba(239,68,68,0.5)',
+                            },
+                            yAxisID: 'y1',
+                            order: 1
+                        }
+                    ]
+                },
+                options: {
+                    responsive: true,
+                    maintainAspectRatio: false,
+                    interaction: {
+                        mode: 'index',
+                        intersect: false
+                    },
+                    plugins: {
+                        legend: {
+                            position: 'top',
+                            labels: {
+                                color: textColor,
+                                font: { size: 11, weight: '500' },
+                                usePointStyle: true
+                            }
+                        },
+                        tooltip: {
+                            callbacks: {
+                                title: function(items) {
+                                    const idx = items[0].dataIndex;
+                                    const suffix = idx < histCount ? ' ✓ Paid' : ' ⟶ Projected';
+                                    return items[0].label + suffix;
+                                },
+                                label: function(ctx) {
+                                    const val = ctx.parsed.y || 0;
+                                    return ` ${ctx.dataset.label}: {{ loan.currency }}${val.toLocaleString('en-IN')}`;
+                                }
+                            }
+                        }
+                    },
+                    scales: {
+                        x: {
+                            grid: { display: false },
+                            ticks: { color: textColor, font: { size: 10 }, maxRotation: 45, autoSkip: true }
+                        },
+                        y: {
+                            stacked: true,
+                            beginAtZero: true,
+                            grid: { color: gridColor },
+                            ticks: {
+                                color: textColor,
+                                font: { size: 10 },
+                                callback: function(val) {
+                                    return '{{ loan.currency }}' + (val >= 1000 ? (val / 1000).toFixed(0) + 'k' : val);
+                                }
+                            }
+                        },
+                        y1: {
+                            position: 'right',
+                            beginAtZero: true,
+                            grid: { display: false },
+                            ticks: {
+                                color: textColor,
+                                font: { size: 10 },
+                                callback: function(val) {
+                                    return '{{ loan.currency }}' + (val >= 1000 ? (val / 1000).toFixed(0) + 'k' : val);
+                                }
+                            }
+                        }
+                    }
+                }
+            });
+        }
+    }
+
+    document.addEventListener('DOMContentLoaded', renderLoanDetailCharts);
+    document.body.addEventListener('htmx:afterSwap', function(e) {
+        renderLoanDetailCharts();
+    });
     </script>
 
 

--- a/templates/expenses/loan_list.html
+++ b/templates/expenses/loan_list.html
@@ -4,3 +4,152 @@
 {% block content %}
 {% include 'expenses/partials/_loan_list_partial.html' %}
 {% endblock %}
+
+{% block scripts %}
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+<script>
+function renderLoanListCharts() {
+    if (typeof Chart === 'undefined') return;
+    const isDark = document.documentElement.getAttribute('data-bs-theme') === 'dark';
+    const textColor = isDark ? '#e2e8f0' : '#475569';
+    const gridColor = isDark ? 'rgba(255, 255, 255, 0.08)' : 'rgba(0, 0, 0, 0.05)';
+
+    // 1. Doughnut Chart: Portfolio Debt Breakdown
+    const portfolioCtx = document.getElementById('portfolioBreakdownChart');
+    const portfolioDataEl = document.getElementById('portfolio-breakdown-data');
+    if (portfolioCtx && portfolioDataEl) {
+        const existingPortfolio = Chart.getChart(portfolioCtx);
+        if (existingPortfolio) {
+            existingPortfolio.destroy();
+        }
+        try {
+            const data = JSON.parse(portfolioDataEl.textContent);
+            const hasData = data.values && data.values.some(v => v > 0);
+            if (hasData) {
+                new Chart(portfolioCtx, {
+                    type: 'doughnut',
+                    data: {
+                        labels: data.labels,
+                        datasets: [{
+                            data: data.values,
+                            backgroundColor: ['#1D9E75', '#F59E0B', '#EF4444'],
+                            borderWidth: 2,
+                            borderColor: isDark ? '#1e293b' : '#ffffff'
+                        }]
+                    },
+                    options: {
+                        responsive: true,
+                        maintainAspectRatio: false,
+                        animation: false,
+                        plugins: {
+                            legend: {
+                                position: 'bottom',
+                                labels: {
+                                    color: textColor,
+                                    font: { size: 11, weight: '500' },
+                                    padding: 10,
+                                    usePointStyle: true
+                                }
+                            },
+                            tooltip: {
+                                callbacks: {
+                                    label: function(ctx) {
+                                        const val = ctx.parsed || 0;
+                                        return ` ${ctx.label}: {{ user.profile.currency }}${val.toLocaleString()}`;
+                                    }
+                                }
+                            }
+                        },
+                        cutout: '68%'
+                    }
+                });
+            }
+        } catch (err) {
+            console.error('Error rendering portfolio breakdown chart:', err);
+        }
+    }
+
+    // 2. Bar Chart: Loan Principal Progress Comparison
+    const compCtx = document.getElementById('loanComparisonChart');
+    const compDataEl = document.getElementById('loan-comparison-data');
+    if (compCtx && compDataEl) {
+        const existingComp = Chart.getChart(compCtx);
+        if (existingComp) {
+            existingComp.destroy();
+        }
+        try {
+            const data = JSON.parse(compDataEl.textContent);
+            if (data.labels && data.labels.length > 0) {
+                new Chart(compCtx, {
+                    type: 'bar',
+                    data: {
+                        labels: data.labels,
+                        datasets: [
+                            {
+                                label: '{% trans "Principal Paid" %}',
+                                data: data.principal_paid,
+                                backgroundColor: 'rgba(29, 158, 117, 0.85)',
+                                borderRadius: 4
+                            },
+                            {
+                                label: '{% trans "Remaining Principal" %}',
+                                data: data.remaining_principal,
+                                backgroundColor: 'rgba(239, 68, 68, 0.85)',
+                                borderRadius: 4
+                            }
+                        ]
+                    },
+                    options: {
+                        responsive: true,
+                        maintainAspectRatio: false,
+                        animation: false,
+                        plugins: {
+                            legend: {
+                                position: 'top',
+                                labels: {
+                                    color: textColor,
+                                    font: { size: 11, weight: '500' },
+                                    usePointStyle: true
+                                }
+                            },
+                            tooltip: {
+                                callbacks: {
+                                    label: function(ctx) {
+                                        const val = ctx.parsed.y || 0;
+                                        return ` ${ctx.dataset.label}: {{ user.profile.currency }}${val.toLocaleString()}`;
+                                    }
+                                }
+                            }
+                        },
+                        scales: {
+                            x: {
+                                grid: { display: false },
+                                ticks: { color: textColor, font: { size: 10 } }
+                            },
+                            y: {
+                                grid: { color: gridColor },
+                                ticks: { color: textColor, font: { size: 10 } }
+                            }
+                        }
+                    }
+                });
+            }
+        } catch (err) {
+            console.error('Error rendering loan comparison chart:', err);
+        }
+    }
+}
+
+if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', renderLoanListCharts);
+} else {
+    renderLoanListCharts();
+}
+
+document.body.addEventListener('htmx:afterSettle', function(e) {
+    if (e.detail.target && e.detail.target.id === 'loans-shell') {
+        requestAnimationFrame(renderLoanListCharts);
+    }
+});
+</script>
+{% endblock %}

--- a/templates/expenses/partials/_loan_list_partial.html
+++ b/templates/expenses/partials/_loan_list_partial.html
@@ -44,8 +44,13 @@
             </div>
             <div class="col-md-6 text-md-end">
                 <div class="bg-body-tertiary p-3 rounded d-inline-block text-start shadow-sm border">
+                    {% if status_filter == 'inactive' %}
+                    <p class="text-muted small mb-1">{% trans "Remaining Debt (Paid Off)" %}</p>
+                    <h4 class="mb-0 fw-bold text-success">{{ user.profile.currency }}0</h4>
+                    {% else %}
                     <p class="text-muted small mb-1">{% trans "Total Remaining Debt" %}</p>
                     <h4 class="mb-0 fw-bold text-danger">{{ user.profile.currency }}{{ total_debt|compact_amount:user.profile.currency|translate_digits }}</h4>
+                    {% endif %}
                 </div>
             </div>
         </div>
@@ -100,6 +105,38 @@
             <i class="bi bi-plus-lg me-1"></i> {% trans "New Loan" %}
         </a>
     </div>
+
+    {% if loan_summaries %}
+    <!-- Loan Portfolio Visual Analytics Row -->
+    <div class="row g-4 mb-4">
+        <div class="col-12 col-lg-5">
+            <div class="card border-0 shadow-sm rounded-4 h-100">
+                <div class="card-header bg-transparent border-0 p-4 pb-0">
+                    <h5 class="fw-bold mb-0">{% trans "Portfolio Debt Breakdown" %}</h5>
+                    <p class="text-muted small mb-0">{% trans "Distribution of Principal Paid vs. Interest Paid vs. Debt Remaining" %}</p>
+                </div>
+                <div class="card-body p-4">
+                    <div style="position: relative; height: 210px;">
+                        <canvas id="portfolioBreakdownChart"></canvas>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="col-12 col-lg-7">
+            <div class="card border-0 shadow-sm rounded-4 h-100">
+                <div class="card-header bg-transparent border-0 p-4 pb-0">
+                    <h5 class="fw-bold mb-0">{% trans "Loan Principal Progress Comparison" %}</h5>
+                    <p class="text-muted small mb-0">{% trans "Principal paid off vs. remaining principal per loan" %}</p>
+                </div>
+                <div class="card-body p-4">
+                    <div style="position: relative; height: 210px;">
+                        <canvas id="loanComparisonChart"></canvas>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    {% endif %}
 
     <div class="row g-4">
         {% for summary in loan_summaries %}
@@ -190,6 +227,15 @@
         {% endfor %}
     </div>
 </div>
+
+{{ portfolio_breakdown_chart|json_script:"portfolio-breakdown-data" }}
+{{ loan_comparison_chart|json_script:"loan-comparison-data" }}
+
+<script>
+if (typeof renderLoanListCharts === 'function') {
+    renderLoanListCharts();
+}
+</script>
 
 <style>
 .hover-elevate {


### PR DESCRIPTION
Summary

Closes #97

Changes
Added Loan Structure Breakdown doughnut chart showing:
Principal Paid
Interest Paid
Remaining Balance
Added Amortization Trajectory stacked bar + line chart with the full loan timeline:
Historical repayments and capital events (down payments, prepayments) are shown as solid bars.
Future projected payments are shown as faded/translucent bars.
Added a vertical NOW divider separating historical and projected payments.
Tooltips distinguish between Paid and Projected amounts per month.
Added Portfolio Debt Breakdown doughnut chart to the loan list view.
Added Loan Principal Progress Comparison bar chart to the loan list view.
Fixed inactive loan lists to display the correct Paid Off header statistics.
Added empty-state handling for paid-off loans, including historical trajectory data derived from repayments.
Fixed All / Active / Inactive status filter buttons to re-render charts correctly via HTMX.
Added tests covering loan chart data generation.
Testing
Added coverage for loan chart data generation and paid-off loan scenarios.
Verified chart updates when switching between loan status filters.
<img width="1916" height="912" alt="image" src="https://github.com/user-attachments/assets/173ebe32-bbcc-4639-baa0-5b9eb1f10a91" />
<img width="1902" height="910" alt="image" src="https://github.com/user-attachments/assets/8bd6cfd4-accc-469c-950f-581f7fbf8b03" />

Closes #97